### PR TITLE
Make Create Addon system use ICreateAddon

### DIFF
--- a/src/main/java/com/siepert/createapi/CreateAPI.java
+++ b/src/main/java/com/siepert/createapi/CreateAPI.java
@@ -16,27 +16,27 @@ import java.util.List;
 public final class CreateAPI {
 
 
-    private static final List<CreateAddon> ADDONS = new ArrayList<>();
+    private static final List<ICreateAddon> ADDONS = new ArrayList<>();
 
     /**
      * Registers a Create addon.
      * @param addon Your addon.
      */
-    public static void registerAddon(CreateAddon addon) {
+    public static void registerAddon(ICreateAddon addon) {
         if (!isModAlreadyRegistered(addon.getModId())) {
             ADDONS.add(addon);
         }
     }
 
     private static boolean isModAlreadyRegistered(@Nonnull String id) {
-        for (CreateAddon addon : ADDONS) {
+        for (ICreateAddon addon : ADDONS) {
             if (addon.getModId().equals(id)) return true;
         }
         return false;
     }
 
-    private static final List<CreateAddon> ADDONS_IN_PRIORITY = new ArrayList<>();
-    public static List<CreateAddon> getAddons() {
+    private static final List<ICreateAddon> ADDONS_IN_PRIORITY = new ArrayList<>();
+    public static List<ICreateAddon> getAddons() {
         return ADDONS_IN_PRIORITY;
     }
 
@@ -44,13 +44,13 @@ public final class CreateAPI {
     public static void consumeAddons() {
         int lowestInt = 0;
         int highestInt = 0;
-        for (CreateAddon addon : ADDONS) {
+        for (ICreateAddon addon : ADDONS) {
             if (addon.getLoadPriority() < lowestInt) lowestInt = addon.getLoadPriority();
             if (addon.getLoadPriority() > highestInt) highestInt = addon.getLoadPriority();
         }
 
         for (int i = lowestInt; i <= highestInt; i++) {
-            for (CreateAddon addon : ADDONS) {
+            for (ICreateAddon addon : ADDONS) {
                 if (addon.getLoadPriority() == i) ADDONS_IN_PRIORITY.add(addon);
             }
         }

--- a/src/main/java/com/siepert/createapi/CreateAddon.java
+++ b/src/main/java/com/siepert/createapi/CreateAddon.java
@@ -1,19 +1,11 @@
 package com.siepert.createapi;
 
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-
-public abstract class CreateAddon {
+/* Example implementation of ICreateAddon */
+public abstract class CreateAddon implements ICreateAddon {
     private final int loadPriority;
     private final String modId;
     private final int madeForCreateVersion;
     private final int madeForKineticVersion;
-
-    public int getCreateVersion() {
-        return madeForCreateVersion;
-    }
-    public int getKineticVersion() {
-        return madeForKineticVersion;
-    }
 
     public CreateAddon(String modId, int c, int k) {
         this.modId = modId;
@@ -28,12 +20,20 @@ public abstract class CreateAddon {
         madeForKineticVersion = k;
     }
 
+    @Override
+    public int getCreateVersion() {
+        return madeForCreateVersion;
+    }
+    @Override
+    public int getKineticVersion() {
+        return madeForKineticVersion;
+    }
+    @Override
     public int getLoadPriority() {
         return loadPriority;
     }
+    @Override
     public String getModId() {
         return modId;
     }
-
-    public abstract void onLoad(FMLInitializationEvent initializationEvent);
 }

--- a/src/main/java/com/siepert/createapi/ICreateAddon.java
+++ b/src/main/java/com/siepert/createapi/ICreateAddon.java
@@ -1,0 +1,11 @@
+package com.siepert.createapi;
+
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+public interface ICreateAddon {
+    int getCreateVersion(); // Refer to com.siepert.createlegacy.CreateLegacyModData for your version of Create Legacy
+    int getKineticVersion(); // Refer to com.siepert.createlegacy.CreateLegacyModData for your version of the Kinetic System
+    public int getLoadPriority();
+    String getModId();
+    void onLoad(FMLInitializationEvent initializationEvent);
+}

--- a/src/main/java/com/siepert/createlegacy/CreateLegacy.java
+++ b/src/main/java/com/siepert/createlegacy/CreateLegacy.java
@@ -3,6 +3,7 @@ package com.siepert.createlegacy;
 import com.siepert.createapi.AddonLoadException;
 import com.siepert.createapi.CreateAPI;
 import com.siepert.createapi.CreateAddon;
+import com.siepert.createapi.ICreateAddon;
 import com.siepert.createlegacy.proxy.CommonProxy;
 import com.siepert.createlegacy.tabs.CreateModDecoTab;
 import com.siepert.createlegacy.tabs.CreateModOtherTab;
@@ -45,7 +46,7 @@ public final class CreateLegacy {
         logger.info("Found {} addons to load", CreateAPI.getAddons().size());
         int totalErrors = 0;
         int totalAddons = 0;
-        for (CreateAddon addon : CreateAPI.getAddons()) {
+        for (ICreateAddon addon : CreateAPI.getAddons()) {
             int errors = 0;
             logger.info("Begun loading addon {} (priority index {})",
                     addon.getModId(), addon.getLoadPriority());


### PR DESCRIPTION
# Description
This PR only changes the addon system to accept classes implementing `ICreateAddon` or extending `CreateAddon` (which now implements `ICreateAddon`), this makes it easier for mod developers to make integration for Create Legacy without hard-depending on it

# What did I change
- Created a new interface `ICreateAddon` which defines all methods previously contained in `CreateAddon`
- Change `CreateAddon` to implement `ICreateAddon`
- Change `CreateAPI` to accept all `ICreateAddon`s, and by extension **still supporting addons built by extending `CreateAddon`**

# Backwards compatibility?
Since classes extending `CreateAddon` are also thereby implementing `ICreateAddon` no addons built on the old system should break

# Expected issues?
I don't expect any