### PR TITLE
Add a config system

### DIFF
--- a/src/main/java/com/siepert/createapi/CreateAPI.java
+++ b/src/main/java/com/siepert/createapi/CreateAPI.java
@@ -16,27 +16,27 @@ import java.util.List;
 public final class CreateAPI {
 
 
-    private static final List<CreateAddon> ADDONS = new ArrayList<>();
+    private static final List<ICreateAddon> ADDONS = new ArrayList<>();
 
     /**
      * Registers a Create addon.
      * @param addon Your addon.
      */
-    public static void registerAddon(CreateAddon addon) {
+    public static void registerAddon(ICreateAddon addon) {
         if (!isModAlreadyRegistered(addon.getModId())) {
             ADDONS.add(addon);
         }
     }
 
     private static boolean isModAlreadyRegistered(@Nonnull String id) {
-        for (CreateAddon addon : ADDONS) {
+        for (ICreateAddon addon : ADDONS) {
             if (addon.getModId().equals(id)) return true;
         }
         return false;
     }
 
-    private static final List<CreateAddon> ADDONS_IN_PRIORITY = new ArrayList<>();
-    public static List<CreateAddon> getAddons() {
+    private static final List<ICreateAddon> ADDONS_IN_PRIORITY = new ArrayList<>();
+    public static List<ICreateAddon> getAddons() {
         return ADDONS_IN_PRIORITY;
     }
 
@@ -44,13 +44,13 @@ public final class CreateAPI {
     public static void consumeAddons() {
         int lowestInt = 0;
         int highestInt = 0;
-        for (CreateAddon addon : ADDONS) {
+        for (ICreateAddon addon : ADDONS) {
             if (addon.getLoadPriority() < lowestInt) lowestInt = addon.getLoadPriority();
             if (addon.getLoadPriority() > highestInt) highestInt = addon.getLoadPriority();
         }
 
         for (int i = lowestInt; i <= highestInt; i++) {
-            for (CreateAddon addon : ADDONS) {
+            for (ICreateAddon addon : ADDONS) {
                 if (addon.getLoadPriority() == i) ADDONS_IN_PRIORITY.add(addon);
             }
         }

--- a/src/main/java/com/siepert/createapi/CreateAddon.java
+++ b/src/main/java/com/siepert/createapi/CreateAddon.java
@@ -1,19 +1,11 @@
 package com.siepert.createapi;
 
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-
-public abstract class CreateAddon {
+/* Example implementation of ICreateAddon */
+public abstract class CreateAddon implements ICreateAddon {
     private final int loadPriority;
     private final String modId;
     private final int madeForCreateVersion;
     private final int madeForKineticVersion;
-
-    public int getCreateVersion() {
-        return madeForCreateVersion;
-    }
-    public int getKineticVersion() {
-        return madeForKineticVersion;
-    }
 
     public CreateAddon(String modId, int c, int k) {
         this.modId = modId;
@@ -28,12 +20,20 @@ public abstract class CreateAddon {
         madeForKineticVersion = k;
     }
 
+    @Override
+    public int getCreateVersion() {
+        return madeForCreateVersion;
+    }
+    @Override
+    public int getKineticVersion() {
+        return madeForKineticVersion;
+    }
+    @Override
     public int getLoadPriority() {
         return loadPriority;
     }
+    @Override
     public String getModId() {
         return modId;
     }
-
-    public abstract void onLoad(FMLInitializationEvent initializationEvent);
 }

--- a/src/main/java/com/siepert/createapi/ICreateAddon.java
+++ b/src/main/java/com/siepert/createapi/ICreateAddon.java
@@ -1,0 +1,11 @@
+package com.siepert.createapi;
+
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+public interface ICreateAddon {
+    int getCreateVersion(); // Refer to com.siepert.createlegacy.CreateLegacyModData for your version of Create Legacy
+    int getKineticVersion(); // Refer to com.siepert.createlegacy.CreateLegacyModData for your version of the Kinetic System
+    public int getLoadPriority();
+    String getModId();
+    void onLoad(FMLInitializationEvent initializationEvent);
+}

--- a/src/main/java/com/siepert/createlegacy/ConfigHolder.java
+++ b/src/main/java/com/siepert/createlegacy/ConfigHolder.java
@@ -1,0 +1,22 @@
+package com.siepert.createlegacy;
+
+import net.minecraftforge.common.config.Config;
+
+@Config(modid = CreateLegacyModData.MOD_ID, name = CreateLegacyModData.MOD_ID + '/' + CreateLegacyModData.MOD_ID)
+public class ConfigHolder {
+    @Config.Comment("Config options for Create Legacy World Generation")
+    @Config.Name("Worldgen Options")
+    @Config.RequiresMcRestart
+    public static WorldgenOptions worldgen = new WorldgenOptions();
+    public static class WorldgenOptions {
+        @Config.Comment({ "Whether to generate ores from Create Legacy (for example copper ore)",
+                "Default: true" })
+        public boolean generateCreateOres = true;
+        @Config.Comment({ "Whether to generate stone types from Create Legacy (for example limestone)",
+                "Default: true" })
+        public boolean generateCreateStoneTypes = true;
+        @Config.Comment({ "Whether to generate structures from Create Legacy",
+                "Default: true" })
+        public boolean generateCreateStructures = true;
+    }
+}

--- a/src/main/java/com/siepert/createlegacy/ConfigHolder.java
+++ b/src/main/java/com/siepert/createlegacy/ConfigHolder.java
@@ -6,7 +6,7 @@ import net.minecraftforge.common.config.Config;
 public class ConfigHolder {
     @Config.Comment("Config options for Create Legacy World Generation")
     @Config.Name("Worldgen Options")
-    @Config.RequiresMcRestart
+    @Config.RequiresMcRestart // I'm not 100% sure if it requires an MC restart, but you should probably make a new world
     public static WorldgenOptions worldgen = new WorldgenOptions();
     public static class WorldgenOptions {
         @Config.Comment({ "Whether to generate ores from Create Legacy (for example copper ore)",

--- a/src/main/java/com/siepert/createlegacy/CreateLegacy.java
+++ b/src/main/java/com/siepert/createlegacy/CreateLegacy.java
@@ -3,6 +3,7 @@ package com.siepert.createlegacy;
 import com.siepert.createapi.AddonLoadException;
 import com.siepert.createapi.CreateAPI;
 import com.siepert.createapi.CreateAddon;
+import com.siepert.createapi.ICreateAddon;
 import com.siepert.createlegacy.proxy.CommonProxy;
 import com.siepert.createlegacy.tabs.CreateModDecoTab;
 import com.siepert.createlegacy.tabs.CreateModOtherTab;
@@ -45,7 +46,7 @@ public final class CreateLegacy {
         logger.info("Found {} addons to load", CreateAPI.getAddons().size());
         int totalErrors = 0;
         int totalAddons = 0;
-        for (CreateAddon addon : CreateAPI.getAddons()) {
+        for (ICreateAddon addon : CreateAPI.getAddons()) {
             int errors = 0;
             logger.info("Begun loading addon {} (priority index {})",
                     addon.getModId(), addon.getLoadPriority());

--- a/src/main/java/com/siepert/createlegacy/world/gen/WorldGenCustomOres.java
+++ b/src/main/java/com/siepert/createlegacy/world/gen/WorldGenCustomOres.java
@@ -1,5 +1,6 @@
 package com.siepert.createlegacy.world.gen;
 
+import com.siepert.createlegacy.ConfigHolder;
 import com.siepert.createlegacy.blocks.BlockOre;
 import com.siepert.createlegacy.blocks.BlockStone;
 import com.siepert.createlegacy.mainRegistry.ModBlocks;
@@ -61,22 +62,27 @@ public class WorldGenCustomOres implements IWorldGenerator {
                          IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
         switch (world.provider.getDimension()) {
             case -1:
-                runGenerator(stone_scoria, world, random, chunkX, chunkZ, 3, 10, 70);
-                runGenerator(stone_scorchia, world, random, chunkX, chunkZ, 3, 60, 110);
+                if (ConfigHolder.worldgen.generateCreateStoneTypes) {
+                    runGenerator(stone_scoria, world, random, chunkX, chunkZ, 3, 10, 70);
+                    runGenerator(stone_scorchia, world, random, chunkX, chunkZ, 3, 60, 110);
+                }
                 break;
 
             case 0:
-                runGenerator(ore_copper, world, random, chunkX, chunkZ, 8, 25, 128);
-                runGenerator(ore_zinc, world, random, chunkX, chunkZ, 7, 5, 40);
+                if (ConfigHolder.worldgen.generateCreateOres) {
+                    runGenerator(ore_copper, world, random, chunkX, chunkZ, 8, 25, 128);
+                    runGenerator(ore_zinc, world, random, chunkX, chunkZ, 7, 5, 40);
+                }
 
-                runGenerator(stone_calcite, world, random, chunkX, chunkZ, 4, 20, 40, 2);
-                runGenerator(stone_tuff, world, random, chunkX, chunkZ, 4, 0, 20);
-
-                runGenerator(stone_asurine, world, random, chunkX, chunkZ, 1, 10, 40, 5);
-                runGenerator(stone_crimsite, world, random, chunkX, chunkZ, 1, 40, 64, 2);
-                runGenerator(stone_limestone, world, random, chunkX, chunkZ, 1, 30, 50,5);
-                runGenerator(stone_ochrum, world, random, chunkX, chunkZ, 1, 10, 40, 5);
-                runGenerator(stone_veridium, world, random, chunkX, chunkZ, 1, 40, 64, 5);
+                if (ConfigHolder.worldgen.generateCreateStoneTypes) {
+                    runGenerator(stone_calcite, world, random, chunkX, chunkZ, 4, 20, 40, 2);
+                    runGenerator(stone_tuff, world, random, chunkX, chunkZ, 4, 0, 20);
+                    runGenerator(stone_asurine, world, random, chunkX, chunkZ, 1, 10, 40, 5);
+                    runGenerator(stone_crimsite, world, random, chunkX, chunkZ, 1, 40, 64, 2);
+                    runGenerator(stone_limestone, world, random, chunkX, chunkZ, 1, 30, 50, 5);
+                    runGenerator(stone_ochrum, world, random, chunkX, chunkZ, 1, 10, 40, 5);
+                    runGenerator(stone_veridium, world, random, chunkX, chunkZ, 1, 40, 64, 5);
+                }
                 break;
 
             case 1:


### PR DESCRIPTION
# Description
### This PR can only be merged after my other PR: [Pull request #4](<https://github.com/Siepert123/create-legacy/pull/4>) unless you want to manually do the changes (what I'm saying is: I forgot to revert the codebase back to old before coding for this PR)
Added a configuration system based on `ConfigHolder` and used it to add issue #2's feature suggestion of making worldgen optional and configurable

# What did I change
- Added ConfigHolder which uses forge's `@Config` to automatically generate and read config files
- Changed `WorldGenCustomOres` to only generate Ores &/ Create-Specific stone types if enabled in the config

# Backwards compatibility?
There shouldn't be any issues with backwards compatibility

# Expected issues?
Not expecting any issues with this PR